### PR TITLE
Optimize the code size for SolidRun builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           DDR_TYPE=DDR4 \
           DDR_SIZE=${{ matrix.ddr_size }} \
           SWIZZLE=${{ matrix.swizzle }} \
-          FILENAME_ADD=_${{ matrix.device }}_HUMMINGBOARD -f makefile.linaro
+          FILENAME_ADD=_${{ matrix.device }}_HUMMINGBOARD -f makefile.solidrun
 
       - name: Copy firmware
         run: |

--- a/emmc_init.c
+++ b/emmc_init.c
@@ -55,7 +55,7 @@ static void InitMmcPinFunction(void);
  * @retval EMMC_SUCCESS successful.
  * @retval EMMC_ERR error from interrupt API.
  */
-EMMC_ERROR_CODE emmc_init(uint8_t low_clock_mode_enable)
+EMMC_ERROR_CODE __attribute__((optimize("O0"))) emmc_init(uint8_t low_clock_mode_enable)
 {
 	EMMC_ERROR_CODE retult;
 
@@ -86,7 +86,7 @@ EMMC_ERROR_CODE emmc_init(uint8_t low_clock_mode_enable)
  * 
  * @return None.
  */
-EMMC_ERROR_CODE emmc_terminate (void)
+EMMC_ERROR_CODE __attribute__((optimize("O0"))) emmc_terminate (void)
 {
     EMMC_ERROR_CODE result;
 
@@ -202,7 +202,7 @@ __inline static void emmc_set_data_timeout (
  * 
  * @return None.
  */
-static void emmc_drv_init(void)
+static void __attribute__((optimize("O0"))) emmc_drv_init(void)
 {
     /* initialize */
     emmc_memset((uint8_t *)(&mmc_drv_obj), 0, sizeof(st_mmc_base));

--- a/main.c
+++ b/main.c
@@ -9,13 +9,8 @@
 #include "dgtable.h"
 #include "bit.h"
 #include "cpudrv.h"
-#if EMMC == 1
-#include "dgemmc.h"
-#endif /* EMMC == 1 */
 #include "scifdrv.h"
 #include "devdrv.h"
-#include "rpcqspidrv.h"
-#include "dgmodul1.h"
 #include "dgmodul4.h"
 #include "tzc_400.h"
 #include "mmio.h"
@@ -24,6 +19,13 @@
 #include "syc.h"
 #include "ddr.h"
 #include "sysc.h"
+#if (SERIAL_FLASH == 1)
+#include "rpcqspidrv.h"
+#include "dgmodul1.h"
+#endif
+#if EMMC == 1
+#include "dgemmc.h"
+#endif /* EMMC == 1 */
 
 #define	RZG2L_DEVID		(0x841C447)
 #define	RZV2L_DEVID		(0x8447447)
@@ -45,10 +47,8 @@ uint32_t gDumpStatus;
 
 #define RZG2L_SYC_INCK_HZ           (24000000)
 
-void Main(void)
+void __attribute__((optimize("O0"))) Main(void)
 {
-	uint32_t readDevId;
-
 	init_tzc_400_spimulti();
 
 	/* early setup Clock and Reset */
@@ -74,9 +74,6 @@ void Main(void)
 	gDumpMode	= SIZE_8BIT;
 	gDumpStatus	= DISABLE;
 
-	InitRPC_Mode();
-	ReadQspiFlashID(&readDevId);	/* dummy	*/
-
 	InitMain();
 	StartMess();
 	DecCom();
@@ -84,6 +81,12 @@ void Main(void)
 
 void InitMain(void)
 {
+#if (SERIAL_FLASH == 1)
+	uint32_t readDevId;
+
+	InitRPC_Mode();
+	ReadQspiFlashID(&readDevId);	/* dummy	*/
+#endif
 #if EMMC == 1
 	dg_init_emmc();
 #endif /* EMMC == 1 */
@@ -140,7 +143,7 @@ void DecCom(void)
 	char tmp[64], chCnt, chPtr;
 	uint32_t rtn = 0;
 	uint32_t res;
-	chCnt = 1;
+	chCnt = 0;
 
 	while (rtn == 0)
 	{

--- a/makefile.solidrun
+++ b/makefile.solidrun
@@ -1,0 +1,329 @@
+#
+# Copyright (c) 2021, Renesas Electronics Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+HOST_ARCH := $(shell uname -m)
+
+# Select SERIAL_FLASH("ENABLE"or"DISABLE" )
+ifeq ("$(SERIAL_FLASH)", "")
+SERIAL_FLASH = DISABLE
+endif
+
+# Select EMMC("ENABLE"or"DISABLE" )
+ifeq ("$(EMMC)", "")
+EMMC = ENABLE
+endif
+
+# Select QSPI IO Voltage("1_8V"or"3_3V" )
+ifeq ("$(QSPI_IOV)", "")
+QSPI_IOV=1_8V
+endif
+
+# Select eMMC IO Voltage("1_8V"or"3_3V" )
+ifeq ("$(EMMC_IOV)", "")
+EMMC_IOV=1_8V
+endif
+
+ifeq ("$(INTERNAL_MEMORY_ONLY)", "")
+INTERNAL_MEMORY_ONLY = DISABLE
+endif
+
+ifeq ("$(INTERNAL_MEMORY_ONLY)", "ENABLE")
+DDR_TYPE = INTERNAL
+endif
+
+#CPU
+CPU     = 
+AArch   = 64
+AS_NEON = 
+CC_NEON = -mgeneral-regs-only
+ALIGN   = -mstrict-align
+AArch32_64  = AArch64
+BOOTDIR     = AArch64_boot
+OUTPUT_DIR  = AArch64_output
+OBJECT_DIR  = AArch64_obj
+ifneq ($(HOST_ARCH),aarch64)
+CROSS_COMPILE ?= aarch64-elf-
+endif
+
+CFLAGS += -Os -s -z -fno-stack-protector -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables
+LDFLAGS += --no-warn-rwx-segment 
+BOOT_DEF    = Writer
+FILE_NAME   = $(OUTPUT_DIR)/Flash_Writer_SCIF_$(DEVICE)_$(BOARD)_$(DDR_TYPE)_$(DDR_SIZE)
+
+ifeq ("$(DEVICE)", "RZG2L")
+	CFLAGS += -DRZG2L=1
+endif
+ifeq ("$(DEVICE)", "RZG2LC")
+	CFLAGS += -DRZG2LC=1
+endif
+ifeq ("$(DEVICE)", "RZG2UL")
+	CFLAGS += -DRZG2UL=1
+endif
+ifeq ("$(DEVICE)", "RZV2L")
+	CFLAGS += -DRZV2L=1
+endif
+
+ifeq ("$(DDR_TYPE)", "DDR4")
+	CFLAGS += -DDDR4=1
+endif
+
+ifeq ("$(DDR_SIZE)", "4GB")
+	CFLAGS += -DDDR_SIZE_4GB=1
+endif
+ifeq ("$(DDR_SIZE)", "2GB")
+	CFLAGS += -DDDR_SIZE_2GB=1
+endif
+ifeq ("$(DDR_SIZE)", "2GB_1PCS")
+	CFLAGS += -DDDR_SIZE_2GB_1PCS=1
+endif
+ifeq ("$(DDR_SIZE)", "1GB")
+	CFLAGS += -DDDR_SIZE_1GB=1
+endif
+ifeq ("$(DDR_SIZE)", "1GB_1PCS")
+	CFLAGS += -DDDR_SIZE_1GB_1PCS=1
+endif
+ifeq ("$(DDR_SIZE)", "512MB_1PCS")
+	CFLAGS += -DDDR_SIZE_512MB_1PCS=1
+endif
+
+ifeq ("$(SWIZZLE)", "T1C")
+	CFLAGS += -DSWIZZLE_T1C=1
+endif
+
+ifeq ("$(SWIZZLE)", "T1BC")
+	CFLAGS += -DSWIZZLE_T1BC=1
+endif
+
+ifeq ("$(SWIZZLE)", "T2C")
+	CFLAGS += -DSWIZZLE_T2C=1
+endif
+
+ifeq ("$(SWIZZLE)", "T3BC")
+	CFLAGS += -DSWIZZLE_T3BC=1
+endif
+
+ifeq ("$(SWIZZLE)", "T3CL")
+	CFLAGS += -DSWIZZLE_T3CL=1
+endif
+
+ifeq ("$(SWIZZLE)", "T3BCUL")
+	CFLAGS += -DSWIZZLE_T3BCUL=1
+endif
+
+ifeq ("$(SWIZZLE)", "T3BCUD")
+	CFLAGS += -DSWIZZLE_T3BCUD=1
+endif
+
+ifeq ("$(SWIZZLE)", "T3BCUD2")
+	CFLAGS += -DSWIZZLE_T3BCUD2=1
+endif
+
+ifeq ("$(DEVICE_TYPE)", "1")
+	CFLAGS += -DDEVICE_TYPE=1
+endif
+
+ifeq ("$(DEVICE_TYPE)", "2")
+	CFLAGS += -DDEVICE_TYPE=2
+endif
+
+ifeq ("$(SERIAL_FLASH)", "ENABLE")
+	CFLAGS += -DSERIAL_FLASH=1
+else
+	CFLAGS += -DSERIAL_FLASH=0
+endif
+
+ifeq ("$(EMMC)", "ENABLE")
+	CFLAGS += -DEMMC=1
+else
+	CFLAGS += -DEMMC=0
+endif
+
+ifeq ("$(QSPI_IOV)", "1_8V")
+	CFLAGS += -DQSPI_IO_1_8V=1
+endif
+
+ifeq ("$(EMMC_IOV)", "1_8V")
+	CFLAGS += -DEMMC_IO_1_8V=1
+endif
+
+ifeq ("$(INTERNAL_MEMORY_ONLY)", "DISABLE")
+	CFLAGS += -DINTERNAL_MEMORY_ONLY=0
+	LINKER_FILE = memory_writer.def.s
+endif
+
+ifeq ("$(INTERNAL_MEMORY_ONLY)", "ENABLE")
+	CFLAGS += -Os -DINTERNAL_MEMORY_ONLY=1
+	LINKER_FILE = memory_writer_internal.def.s
+endif
+
+ifeq ("$(TRUSTED_BOARD_BOOT)", "ENABLE")
+	CFLAGS += -DTRUSTED_BOARD_BOOT=1
+endif
+
+MEMORY_DEF := $(LINKER_FILE:%.def.s=$(OBJECT_DIR)/%.def)
+
+DDR_DEF = ddr_qos_init_setting
+
+# LIBS        = -L$(subst libc.a, ,$(shell $(CC) -print-file-name=libc.a 2> /dev/null)) -lc
+
+INCLUDE_DIR = include
+DDR_COMMON = ddr/common
+ifeq ("$(DEVICE)", "RZV2L")
+DDR_SOC    = ddr/v2l
+else ifeq ("$(DEVICE)", "RZG2UL")
+DDR_SOC    = ddr/g2ul
+else
+DDR_SOC    = ddr/g2l
+endif
+TOOL_DEF = "REWRITE_TOOL"
+
+OUTPUT_FILE = $(FILE_NAME).axf
+
+#Object file
+OBJ_FILE_BOOT =				\
+	$(OBJECT_DIR)/boot_mon.o	\
+	$(OBJECT_DIR)/stack.o
+
+SRC_FILE :=				\
+	main.c				\
+	init_scif.c			\
+	scifdrv.c			\
+	devdrv.c			\
+	common.c			\
+	dgtable.c			\
+	dgmodul1.c			\
+	memory_cmd.c			\
+	Message.c			\
+	ramckmdl.c			\
+	cpudrv.c			\
+	sys/syc.c			\
+	sys/sysc.c			\
+	sys/cpg.c			\
+	sys/pfc.c			\
+	sys/tzc_400.c
+
+ifeq ("$(INTERNAL_MEMORY_ONLY)", "DISABLE")
+SRC_FILE +=				\
+	ddrcheck.c			\
+	ddr/common/ddr.c
+ifeq ("$(DEVICE)", "RZV2L")
+SRC_FILE +=				\
+	ddr/v2l/ddr_v2l.c
+else ifeq ("$(DEVICE)", "RZG2UL")
+SRC_FILE +=				\
+	ddr/g2ul/ddr_g2ul.c
+else
+SRC_FILE +=				\
+	ddr/g2l/ddr_g2l.c
+endif
+endif
+
+ifeq ("$(SERIAL_FLASH)", "ENABLE")
+SRC_FILE +=				\
+	dgmodul4.c			\
+	rpcqspidrv.c			\
+	spiflash1drv.c
+endif
+
+ifeq ("$(EMMC)", "ENABLE")
+SRC_FILE +=				\
+	dg_emmc_config.c		\
+	dg_emmc_access.c		\
+	emmc_cmd.c			\
+	emmc_init.c			\
+	emmc_interrupt.c		\
+	emmc_mount.c			\
+	emmc_write.c			\
+	emmc_erase.c			\
+	emmc_utility.c
+endif
+
+OBJ_FILE := $(addprefix $(OBJECT_DIR)/,$(patsubst %.c,%.o,$(SRC_FILE)))
+
+#Dependency File
+DEPEND_FILE = $(patsubst %.lib, ,$(OBJ_FILE:%.o=%.d)) $(LINKER_FILE:.s=.d)
+
+###################################################
+#C compiler
+CC = $(CROSS_COMPILE)gcc
+#C++ compiler
+CPP = $(CROSS_COMPILE)cpp
+#Assembler
+AS = $(CROSS_COMPILE)as
+#Linker
+LD = $(CROSS_COMPILE)ld
+#Liblary
+AR = $(CROSS_COMPILE)gcc-ar
+#Object dump
+OBJDUMP = $(CROSS_COMPILE)objdump
+#Object copy
+OBJCOPY = $(CROSS_COMPILE)objcopy
+
+#clean
+CL = rm -rf
+
+###################################################
+# Suffixes
+.SUFFIXES : .S .s .c .o
+
+###################################################
+# Command
+
+.PHONY: all
+all: $(OBJECT_DIR) $(OUTPUT_DIR) $(OBJ_FILE_BOOT) $(OBJ_FILE) $(OUTPUT_FILE) $(MEMORY_DEF)
+
+#------------------------------------------
+# Make Directory
+#------------------------------------------
+$(OBJECT_DIR):
+	-mkdir "$(OBJECT_DIR)"
+
+$(OUTPUT_DIR):
+	-mkdir "$(OUTPUT_DIR)"
+
+#------------------------------------------
+# Compile
+#------------------------------------------
+$(OBJECT_DIR)/%.o:$(BOOTDIR)/%.s
+	$(AS) -g $(CPU) $(AS_NEON) --MD $(patsubst %.o,%.d,$@) -I $(BOOTDIR) -I $(INCLUDE_DIR) -I $(DDR_COMMON) -I $(DDR_SOC) $< -o $@ --defsym $(AArch32_64)=0 --defsym $(BOOT_DEF)=0 --defsym $(TOOL_DEF)=0
+
+$(OBJECT_DIR)/%.o:%.c
+	@if [ ! -e `dirname $@` ]; then mkdir -p `dirname $@`; fi
+	$(CC) -Os $(ALIGN) $(CPU) $(CC_NEON) -MMD -MP -c -I $(BOOTDIR) -I $(INCLUDE_DIR) -I $(DDR_COMMON) -I $(DDR_SOC) $< -o $@ -D$(AArch32_64)=0 -D$(BOOT_DEF)=0 -D$(TOOL_DEF)=0 $(CFLAGS) -D$(DDR_DEF)=0
+
+$(OBJECT_DIR)/%.def:%.def.s
+	@if [ ! -e `dirname $@` ]; then mkdir -p `dirname $@`; fi
+	$(CPP) $(CPU) $(CFLAGS) -I $(BOOTDIR) -I $(INCLUDE_DIR) -x assembler-with-cpp -MMD -MP -P $< -o $@ -D$(AArch32_64)=0 -D$(BOOT_DEF)=0 -D$(TOOL_DEF)=0 -D$(DDR_DEF)=0
+
+#------------------------------------------
+# Linker
+#------------------------------------------
+$(OUTPUT_FILE): $(OBJ_FILE_BOOT) $(OBJ_FILE) $(MEMORY_DEF)
+	$(LD) $(LDFLAGS) $(OBJ_FILE_BOOT) $(OBJ_FILE) 	\
+	-T '$(MEMORY_DEF)'			\
+	-o '$(OUTPUT_FILE)'			\
+	-Map '$(FILE_NAME).map' 		\
+	$(LIBS)					\
+	-static					
+
+#   Make MOT file
+	$(OBJCOPY) -O srec --srec-forceS3 "$(OUTPUT_FILE)" "$(FILE_NAME).mot"
+
+#   Make Binary file
+#	$(OBJCOPY) -O binary "$(OUTPUT_FILE)" "$(FILE_NAME).bin"
+
+#   Dis assemble
+#	$(OBJDUMP) -d -S "$(OUTPUT_FILE)" > "$(FILE_NAME)_disasm.txt"
+
+#	Time Stamp
+	@echo ==========  `date`  ==========
+	@echo ========== !!! Compile Complete !!! ==========
+
+
+.PHONY: clean
+clean:
+	$(CL)  $(OBJECT_DIR)/* $(OUTPUT_DIR)/*
+
+-include $(DEPEND_FILE)

--- a/memory_cmd.c
+++ b/memory_cmd.c
@@ -95,7 +95,7 @@ static void ChgDumpAsciiCode(uintptr_t chCode, char *buf, char chPtr, uint32_t w
 	}
 }
 
-static void ChgDumpAsciiStr(char *buf)
+static void __attribute__((optimize("O0"))) ChgDumpAsciiStr(char *buf)
 {
 	unsigned char i;
 	buf[18] = 0;
@@ -372,7 +372,7 @@ static void dgMemEdit(uint32_t width)
 	COMMAND			: D				*
 	INPUT PARAMETER		: D  {sadr {eadr}}  		*
 *****************************************************************/
-void	dgDump(void)
+void dgDump(void)
 {
 	uintptr_t dmp1st, dmp2nd;
 	char decRtn;


### PR DESCRIPTION
This shrinks the binary builds down to about 147K over 120K smaller than the standard build cutting the load time over serial to almost half.